### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Kolab/Server/Schema/Base.php
+++ b/lib/Horde/Kolab/Server/Schema/Base.php
@@ -64,7 +64,7 @@ implements Horde_Kolab_Server_Schema_Interface
             $this->_handleError($info, Horde_Kolab_Server_Exception::SYSTEM);
             return $info;
         }
-        return parent::getObjectclassSchema($objectclass);
+        return array();
     }
 
     /**
@@ -84,7 +84,7 @@ implements Horde_Kolab_Server_Schema_Interface
             $this->_handleError($info, Horde_Kolab_Server_Exception::SYSTEM);
             return $info;
         }
-        return parent::getAttributeSchema($attribute);
+        return array();
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Kolab/Server/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Kolab/Server/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde KolabServer Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Kolab/Server/Class/Server/Connection/MockTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Connection/MockTest.php
@@ -24,43 +24,45 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Server_Class_Server_Connection_MockTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testMethodConstructHasParameterMockldapConnection()
     {
-        $ldap = $this->getMock(
-            'Horde_Kolab_Server_Connection_Mock_Ldap',
-            array(), array(), '', false, false
-        );
+        $this->expectNotToPerformAssertions();
+
+        $ldap = $this->getMockBuilder('Horde_Kolab_Server_Connection_Mock_Ldap')
+                     ->disableOriginalConstructor()
+                     ->disableOriginalClone()
+                     ->getMock();
         $conn = new Horde_Kolab_Server_Connection_Mock($ldap);
     }
 
     public function testMethodConstructHasPostconditionThatTheGivenServerWasStored()
     {
-        $ldap = $this->getMock(
-            'Horde_Kolab_Server_Connection_Mock_Ldap',
-            array(), array(), '', false, false
-        );
+        $ldap = $this->getMockBuilder('Horde_Kolab_Server_Connection_Mock_Ldap')
+                     ->disableOriginalConstructor()
+                     ->disableOriginalClone()
+                     ->getMock();
         $conn = new Horde_Kolab_Server_Connection_Mock($ldap);
         $this->assertSame($ldap, $conn->getRead());
     }
 
     public function testMethodGetreadHasResultMockldapTheHandledConnection()
     {
-        $ldap = $this->getMock(
-            'Horde_Kolab_Server_Connection_Mock_Ldap',
-            array(), array(), '', false, false
-        );
+        $ldap = $this->getMockBuilder('Horde_Kolab_Server_Connection_Mock_Ldap')
+                     ->disableOriginalConstructor()
+                     ->disableOriginalClone()
+                     ->getMock();
         $conn = new Horde_Kolab_Server_Connection_Mock($ldap);
         $this->assertInstanceOf('Horde_Kolab_Server_Connection_Mock_Ldap', $conn->getRead());
     }
 
     public function testMethodGetwriteHasResultMockldapTheHandledConnection()
     {
-        $ldap = $this->getMock(
-            'Horde_Kolab_Server_Connection_Mock_Ldap',
-            array(), array(), '', false, false
-        );
+        $ldap = $this->getMockBuilder('Horde_Kolab_Server_Connection_Mock_Ldap')
+                     ->disableOriginalConstructor()
+                     ->disableOriginalClone()
+                     ->getMock();
         $conn = new Horde_Kolab_Server_Connection_Mock($ldap);
         $this->assertSame($conn->getWrite(), $conn->getRead());
     }

--- a/test/Horde/Kolab/Server/Class/Server/Connection/SimpleldapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Connection/SimpleldapTest.php
@@ -33,15 +33,17 @@ extends Horde_Kolab_Server_LdapTestCase
 {
     public function testMethodConstructHasParameterNetldap2Connection()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->skipIfNoLdap();
-        $ldap = $this->getMock('Horde_Ldap');
+        $ldap = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Simpleldap($ldap);
     }
 
     public function testMethodConstructHasPostconditionThatTheGivenServerWasStored()
     {
         $this->skipIfNoLdap();
-        $ldap = $this->getMock('Horde_Ldap');
+        $ldap = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Simpleldap($ldap);
         $this->assertSame($ldap, $conn->getRead());
     }
@@ -49,7 +51,7 @@ extends Horde_Kolab_Server_LdapTestCase
     public function testMethodGetreadHasResultNetldap2TheHandledConnection()
     {
         $this->skipIfNoLdap();
-        $ldap = $this->getMock('Horde_Ldap');
+        $ldap = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Simpleldap($ldap);
         $this->assertInstanceOf('Horde_Ldap', $conn->getRead());
     }
@@ -57,7 +59,7 @@ extends Horde_Kolab_Server_LdapTestCase
     public function testMethodGetwriteHasResultNetldap2TheHandledConnection()
     {
         $this->skipIfNoLdap();
-        $ldap = $this->getMock('Horde_Ldap');
+        $ldap = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Simpleldap($ldap);
         $this->assertSame($conn->getWrite(), $conn->getRead());
     }

--- a/test/Horde/Kolab/Server/Class/Server/Connection/SplittedldapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Connection/SplittedldapTest.php
@@ -33,17 +33,19 @@ extends Horde_Kolab_Server_LdapTestCase
 {
     public function testMethodConstructHasParameterNetldap2ReadConnectionAndParameterNetldap2WriteConnection()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->skipIfNoLdap();
-        $ldap_read = $this->getMock('Horde_Ldap');
-        $ldap_write = $this->getMock('Horde_Ldap');
+        $ldap_read = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Splittedldap($ldap_read, $ldap_write);
     }
 
     public function testMethodConstructHasPostconditionThatTheGivenServersWereStored()
     {
         $this->skipIfNoLdap();
-        $ldap_read = $this->getMock('Horde_Ldap');
-        $ldap_write = $this->getMock('Horde_Ldap');
+        $ldap_read = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Splittedldap($ldap_read, $ldap_write);
         $this->assertSame($ldap_read, $conn->getRead());
         $this->assertSame($ldap_write, $conn->getWrite());
@@ -52,8 +54,8 @@ extends Horde_Kolab_Server_LdapTestCase
     public function testMethodGetreadHasResultNetldap2TheHandledConnection()
     {
         $this->skipIfNoLdap();
-        $ldap_read = $this->getMock('Horde_Ldap');
-        $ldap_write = $this->getMock('Horde_Ldap');
+        $ldap_read = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Splittedldap($ldap_read, $ldap_write);
         $this->assertInstanceOf('Horde_Ldap', $conn->getRead());
         $this->assertInstanceOf('Horde_Ldap', $conn->getWrite());
@@ -62,8 +64,8 @@ extends Horde_Kolab_Server_LdapTestCase
     public function testMethodGetwriteHasResultNetldap2TheHandledConnection()
     {
         $this->skipIfNoLdap();
-        $ldap_read = $this->getMock('Horde_Ldap');
-        $ldap_write = $this->getMock('Horde_Ldap');
+        $ldap_read = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $conn = new Horde_Kolab_Server_Connection_Splittedldap($ldap_read, $ldap_write);
         $this->assertFalse($conn->getWrite() === $conn->getRead());
     }

--- a/test/Horde/Kolab/Server/Class/Server/Decorator/CleanTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Decorator/CleanTest.php
@@ -23,13 +23,13 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->server = $this->getMock('Horde_Kolab_Server_Interface');
+        $this->server = $this->getMockBuilder('Horde_Kolab_Server_Interface')->getMock();
         $this->cleaner = new Horde_Kolab_Server_Decorator_Clean($this->server);
     }
 
@@ -79,10 +79,11 @@ class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framew
 
     public function testMethodFindHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
-        $query = $this->getMock(
-            'Horde_Kolab_Server_Query_Element_Interface', array(), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
+        $query = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')
+                      ->disableOriginalConstructor()
+                      ->disableOriginalClone()
+                      ->getMock();
         $this->server->expects($this->exactly(1))
             ->method('find')
             ->with($query)
@@ -95,10 +96,11 @@ class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framew
 
     public function testMethodFindbelowHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
-        $query = $this->getMock(
-            'Horde_Kolab_Server_Query_Element_Interface', array(), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
+        $query = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')
+                      ->disableOriginalConstructor()
+                      ->disableOriginalClone()
+                      ->getMock();
         $this->server->expects($this->exactly(1))
             ->method('findBelow')
             ->with($query, 'none')
@@ -111,7 +113,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framew
 
     public function testMethodSaveHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->server->expects($this->exactly(1))
             ->method('save')
             ->with($object, array('a' => 'a'));
@@ -120,7 +122,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framew
 
     public function testMethodAddHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->server->expects($this->exactly(1))
             ->method('add')
             ->with($object, array('a' => 'a'));
@@ -160,7 +162,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framew
 
     public function testMethodAddHasPostconditionThatTheGuidOfTheAddedObjectIsRememberedAndDeletedOnDestruction()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->exactly(1))
             ->method('getGuid')
             ->will($this->returnValue('a'));
@@ -176,7 +178,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends PHPUnit_Framew
 
     public function testMethodAddHasPostconditionThatTheGuidOfTheAddedObjectIsNotDeletedOnDestructionIfItWasDeletedBefore()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->exactly(1))
             ->method('getGuid')
             ->will($this->returnValue('a'));

--- a/test/Horde/Kolab/Server/Class/Server/Decorator/CleanTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Decorator/CleanTest.php
@@ -23,6 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Decorator_CleanTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Decorator/LogTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Decorator/LogTest.php
@@ -23,6 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Decorator/LogTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Decorator/LogTest.php
@@ -23,14 +23,14 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->logger = $this->getMock('Horde_Log_Logger');
-        $this->server = $this->getMock('Horde_Kolab_Server_Interface');
+        $this->logger = $this->getMockBuilder('Horde_Log_Logger')->getMock();
+        $this->server = $this->getMockBuilder('Horde_Kolab_Server_Interface')->getMock();
         $this->logged = new Horde_Kolab_Server_Decorator_Log(
             $this->server, $this->logger
         );
@@ -82,10 +82,11 @@ class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framewor
 
     public function testMethodFindHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
-        $query = $this->getMock(
-            'Horde_Kolab_Server_Query_Ldap', array(), array(), '', false, false
-        );
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
+        $query = $this->getMockBuilder('Horde_Kolab_Server_Query_Ldap')
+                      ->disableOriginalConstructor()
+                      ->disableOriginalClone()
+                      ->getMock();
         $query->expects($this->once())
             ->method('__toString')
             ->will($this->returnValue('filter'));
@@ -101,10 +102,11 @@ class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framewor
 
     public function testMethodFindbelowHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
-        $query = $this->getMock(
-            'Horde_Kolab_Server_Query_Element_Interface', array(), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
+        $query = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')
+                      ->disableOriginalConstructor()
+                      ->disableOriginalClone()
+                      ->getMock();
         $this->server->expects($this->exactly(1))
             ->method('findBelow')
             ->with($query, 'none')
@@ -117,7 +119,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framewor
 
     public function testMethodSaveHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->server->expects($this->exactly(1))
             ->method('save')
             ->with($object, array('a' => 'a'));
@@ -126,7 +128,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framewor
 
     public function testMethodAddHasPostconditionThatTheCallWasDelegatedToTheServer()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->server->expects($this->exactly(1))
             ->method('add')
             ->with($object, array('a' => 'a'));
@@ -158,7 +160,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framewor
 
     public function testMethodSaveHasPostconditionThatTheEventWasLogged()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('getGuid')
             ->will($this->returnValue('a'));
@@ -172,7 +174,7 @@ class Horde_Kolab_Server_Class_Server_Decorator_LogTest extends PHPUnit_Framewor
 
     public function testMethodAddHasPostconditionThatTheEventWasLogged()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('getGuid')
             ->will($this->returnValue('a'));

--- a/test/Horde/Kolab/Server/Class/Server/Ldap/ChangesTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Ldap/ChangesTest.php
@@ -23,26 +23,32 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends Horde_Test_Case
 {
     public function testMethodConstructHasParameterServerobject()
     {
+        $this->expectNotToPerformAssertions();
+
         $changes = new Horde_Kolab_Server_Ldap_Changes(
-            $this->getMock('Horde_Kolab_Server_Object_Interface'), array()
+            $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock(),
+            array()
         );
     }
 
     public function testMethodConstructHasParameterArrayDataToBeStored()
     {
+        $this->expectNotToPerformAssertions();
+
         $changes = new Horde_Kolab_Server_Ldap_Changes(
-            $this->getMock('Horde_Kolab_Server_Object_Interface'),
+            $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')
+                 ->getMock(),
             array('store' => 'value')
         );
     }
 
     public function testMethodGetchangesetHasResultArrayEmptyIfOldAndNewDatasetsWereEmpty()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array()));
@@ -54,7 +60,7 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArrayEmptyIfOldAndNewDatasetsWereEqual()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array('a' => array('a'))));
@@ -66,7 +72,7 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArrayNewAttributesInNewDatasetAsAdded()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array()));
@@ -85,7 +91,7 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArrayMissingValuesInNewDatasetAsDeleted()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array('old' => 'a')));
@@ -104,12 +110,12 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArraySingleValuesWithDifferencesAsReplaced()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
-            ->will($this->returnValue(array('value' => 'a')));
+            ->will($this->returnValue(array('value' =>  ['a'])));
         $changes = new Horde_Kolab_Server_Ldap_Changes(
-            $object, array('value' => 'b')
+            $object, array('value' => ['b'])
         );
         $this->assertEquals(
             array(
@@ -123,7 +129,7 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArrayTheNewValuesAsAdded()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array('value' => array('a', 'b', 'c'))));
@@ -142,7 +148,7 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArrayTheRemovedValuesAsDeleted()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array('value' => array('a', 'b', 'c'))));
@@ -161,7 +167,7 @@ class Horde_Kolab_Server_Class_Server_Ldap_ChangesTest extends PHPUnit_Framework
 
     public function testMethodGetchangesetHasResultArrayTheNewValuesAsAddedAndTheRemovedValuesAsDeleted()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $object->expects($this->once())
             ->method('readInternal')
             ->will($this->returnValue(array('value' => array('a', 'b', 'c'))));

--- a/test/Horde/Kolab/Server/Class/Server/Ldap/FilteredTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Ldap/FilteredTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Ldap_FilteredTest extends Horde_Kolab_Server_LdapTestCase
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Ldap/FilteredTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Ldap/FilteredTest.php
@@ -30,12 +30,12 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  */
 class Horde_Kolab_Server_Class_Server_Ldap_FilteredTest extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->skipIfNoLdap();
 
-        $this->ldap_read  = $this->getMock('Horde_Ldap');
-        $this->ldap_write = $this->getMock('Horde_Ldap');
+        $this->ldap_read  = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $this->ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $connection = new Horde_Kolab_Server_Connection_Splittedldap(
             $this->ldap_read,
             $this->ldap_write
@@ -50,9 +50,10 @@ class Horde_Kolab_Server_Class_Server_Ldap_FilteredTest extends Horde_Kolab_Serv
 
     private function getSearchResultMock()
     {
-        $result = $this->getMock(
-            'Horde_Ldap_Search', array('asArray', 'count'), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('asArray', 'count'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $result->expects($this->any())
             ->method('asArray')
             ->will($this->returnValue(array(array('dn' => 'test'))));

--- a/test/Horde/Kolab/Server/Class/Server/Ldap/StandardTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Ldap/StandardTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Ldap_StandardTest extends Horde_Kolab_Server_LdapTestCase
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Ldap/StandardTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Ldap/StandardTest.php
@@ -30,12 +30,12 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  */
 class Horde_Kolab_Server_Class_Server_Ldap_StandardTest extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->skipIfNoLdap();
 
-        $this->ldap_read  = $this->getMock('Horde_Ldap');
-        $this->ldap_write = $this->getMock('Horde_Ldap');
+        $this->ldap_read  = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $this->ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $connection = new Horde_Kolab_Server_Connection_Splittedldap(
             $this->ldap_read,
             $this->ldap_write
@@ -49,9 +49,10 @@ class Horde_Kolab_Server_Class_Server_Ldap_StandardTest extends Horde_Kolab_Serv
 
     private function getSearchResultMock()
     {
-        $result = $this->getMock(
-            'Horde_Ldap_Search', array('asArray', 'count'), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('asArray', 'count'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $result->expects($this->any())
             ->method('asArray')
             ->will($this->returnValue(array(array('dn' => 'test'))));

--- a/test/Horde/Kolab/Server/Class/Server/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/LdapTest.php
@@ -28,14 +28,17 @@ require_once __DIR__ . '/../../LdapTestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+
+use PHPUnit\Framework\Constraint\IsInstanceOf;
+
 class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->skipIfNoLdap();
 
-        $this->ldap_read  = $this->getMock('Horde_Ldap');
-        $this->ldap_write = $this->getMock('Horde_Ldap');
+        $this->ldap_read  = $this->getMockBuilder('Horde_Ldap')->getMock();
+        $this->ldap_write = $this->getMockBuilder('Horde_Ldap')->getMock();
         $connection = new Horde_Kolab_Server_Connection_Splittedldap(
             $this->ldap_read,
             $this->ldap_write
@@ -49,9 +52,10 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     private function getSearchResultMock()
     {
-        $result = $this->getMock(
-            'Horde_Ldap_Search', array('asArray', 'count'), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('asArray', 'count'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $result->expects($this->any())
             ->method('asArray')
             ->will($this->returnValue(array(array('dn' => 'test'))));
@@ -68,11 +72,15 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodConnectguidHasStringParameterGuid()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->server->connectGuid('guid', '');
     }
 
     public function testMethodConnectguidHasStringParameterPass()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->server->connectGuid('', 'pass');
     }
 
@@ -161,9 +169,10 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodReadThrowsExceptionIfTheObjectWasNotFound()
     {
-        $result = $this->getMock(
-            'Horde_Ldap_Search', array('asArray', 'count'), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('asArray', 'count'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $result->expects($this->exactly(1))
             ->method('count')
             ->will($this->returnValue(0));
@@ -208,9 +217,10 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodReadAttributesThrowsExceptionIfTheObjectWasNotFound()
     {
-        $result = $this->getMock(
-            'Horde_Ldap_Search', array('asArray', 'count'), array(), '', false
-        );
+        $result = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('asArray', 'count'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $result->expects($this->exactly(1))
             ->method('count')
             ->will($this->returnValue(0));
@@ -273,16 +283,16 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodSaveHasParameterObjectTheObjectToModifyOnTheServer()
     {
-        $entry = $this->getMock(
-            'Horde_Ldap_Entry', array(), array(), '', false
-        );
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $entry = $this->getMockBuilder('Horde_Ldap_Entry')
+                      ->disableOriginalConstructor()
+                      ->getMock();
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('getEntry')
             ->will($this->returnValue($entry));
         $this->ldap_write->expects($this->exactly(1))
             ->method('modify')
-            ->with(new PHPUnit_Framework_Constraint_IsInstanceOf('Horde_Ldap_Entry'));
+            ->with(new IsInstanceOf('Horde_Ldap_Entry'));
         $object->expects($this->exactly(1))
             ->method('readInternal')
             ->will($this->returnValue(array()));
@@ -291,16 +301,16 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodSaveHasParameterArrayData()
     {
-        $entry = $this->getMock(
-            'Horde_Ldap_Entry', array(), array(), '', false
-        );
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $entry = $this->getMockBuilder('Horde_Ldap_Entry')
+                      ->disableOriginalConstructor()
+                      ->getMock();
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('getEntry')
             ->will($this->returnValue($entry));
         $this->ldap_write->expects($this->exactly(1))
             ->method('modify')
-            ->with(new PHPUnit_Framework_Constraint_IsInstanceOf('Horde_Ldap_Entry'));
+            ->with(new IsInstanceOf('Horde_Ldap_Entry'));
         $object->expects($this->exactly(1))
             ->method('readInternal')
             ->will($this->returnValue(array()));
@@ -309,16 +319,16 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodSaveHasPostconditionThatTheEntryWasModified()
     {
-        $entry = $this->getMock(
-            'Horde_Ldap_Entry', array(), array(), '', false
-        );
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $entry = $this->getMockBuilder('Horde_Ldap_Entry')
+                      ->disableOriginalConstructor()
+                      ->getMock();
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('getEntry')
             ->will($this->returnValue($entry));
         $this->ldap_write->expects($this->exactly(1))
             ->method('modify')
-            ->with(new PHPUnit_Framework_Constraint_IsInstanceOf('Horde_Ldap_Entry'));
+            ->with(new IsInstanceOf('Horde_Ldap_Entry'));
         $object->expects($this->exactly(1))
             ->method('readInternal')
             ->will($this->returnValue(array()));
@@ -327,7 +337,7 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodSaveThrowsExceptionIfSavingDataFailed()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('modify')
             ->will($this->throwException(new Horde_Ldap_Exception('Saving failed!')));
@@ -345,34 +355,34 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
     public function testMethodAddHasParameterObjectTheObjectToAddToTheServer()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('add')
-            ->with(new PHPUnit_Framework_Constraint_IsInstanceOf('Horde_Ldap_Entry'));
+            ->with(new IsInstanceOf('Horde_Ldap_Entry'));
         $this->server->add($object, array('attributes' => array('dn')));
     }
 
     public function testMethodAddHasParameterArrayData()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('add')
-            ->with(new PHPUnit_Framework_Constraint_IsInstanceOf('Horde_Ldap_Entry'));
+            ->with(new IsInstanceOf('Horde_Ldap_Entry'));
         $this->server->add($object, array('dn' => 'test'));
     }
 
     public function testMethodAddHasPostconditionThatTheEntryWasModified()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('add')
-            ->with(new PHPUnit_Framework_Constraint_IsInstanceOf('Horde_Ldap_Entry'));
+            ->with(new IsInstanceOf('Horde_Ldap_Entry'));
         $this->server->add($object, array('dn' => 'test'));
     }
 
     public function testMethodAddThrowsExceptionIfSavingDataFailed()
     {
-        $object = $this->getMock('Horde_Kolab_Server_Object_Interface');
+        $object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')->getMock();
         $this->ldap_write->expects($this->exactly(1))
             ->method('add')
             ->will($this->throwException(new Horde_Ldap_Exception('Saving failed!')));
@@ -487,7 +497,7 @@ class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTe
 
 /*     public function testMethodSearchReturnsArrayMappedSearchResultIfMappingIsActivated() */
 /*     { */
-/*         $ldap = $this->getMock('Horde_Ldap', array('search')); */
+/*         $ldap = $this->getMockBuilder('Horde_Ldap', array('search'))->getMock(); */
 /*         $ldap->expects($this->exactly(1)) */
 /*             ->method('search') */
 /*             ->will($this->returnValue(new Search_Mock(array(array('dn2' => 'test'))))); */

--- a/test/Horde/Kolab/Server/Class/Server/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/LdapTest.php
@@ -31,6 +31,7 @@ require_once __DIR__ . '/../../LdapTestCase.php';
 
 use PHPUnit\Framework\Constraint\IsInstanceOf;
 
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Object/Attribute/BaseTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Object/Attribute/BaseTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Object_Attribute_BaseTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Object/Attribute/BaseTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Object/Attribute/BaseTest.php
@@ -31,20 +31,22 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Object_Attribute_BaseTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->attribute = $this->getMock(
-            'Horde_Kolab_Server_Structure_Attribute_Interface'
-        );
+        $this->attribute = $this->getMockBuilder('Horde_Kolab_Server_Structure_Attribute_Interface')->getMock();
     }
 
     public function testMethodConstructHasParameterAttributeTheAdapterCoveringTheInternalSideOfTheAttribute()
     {
+        $this->expectNotToPerformAssertions();
+
         $attribute = new Attribute_Mock($this->attribute, '');
     }
 
     public function testMethodConstructHasParameterStringTheNameOfTheAttribute()
     {
+        $this->expectNotToPerformAssertions();
+
         $attribute = new Attribute_Mock($this->attribute, 'name');
     }
 
@@ -65,6 +67,8 @@ extends Horde_Kolab_Server_TestCase
 
     public function testMethodIsemptyHasParameterArrayDataValues()
     {
+        $this->expectNotToPerformAssertions();
+
         $attribute = new Attribute_Mock($this->attribute, 'name');
         $attribute->isEmpty(array());
     }

--- a/test/Horde/Kolab/Server/Class/Server/Object/Attribute/ValueTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Object/Attribute/ValueTest.php
@@ -24,18 +24,19 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Server_Class_Server_Object_Attribute_ValueTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Needs to be fixed');
 
-        $this->object = $this->getMock(
-            'Horde_Kolab_Server_Object_Interface', array(), array(), '', false
-        );
-        $this->composite = $this->getMock(
-            'Horde_Kolab_Server_Composite', array(), array(), '', false
-        );
+        $this->object = $this->getMockBuilder('Horde_Kolab_Server_Object_Interface')
+                             ->disableOriginalConstructor()
+                             ->getMock();
+
+        $this->composite = $this->getMockBuilder('Horde_Kolab_Server_Composite')
+                                ->disableOriginalConstructor()
+                                ->getMock();
     }
 
     public function testMethodValueHasResultArrayTheValuesOfTheAttribute()

--- a/test/Horde/Kolab/Server/Class/Server/Object/BaseTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Object/BaseTest.php
@@ -30,18 +30,22 @@ require_once __DIR__ . '/../../../TestCase.php';
  */
 class Horde_Kolab_Server_Class_Server_Object_BaseTest extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 
     public function testMethodConstructHasParameterCompositeWhichIsTheLinkToTheServer()
     {
+        $this->expectNotToPerformAssertions();
+
         $composite = $this->getComposite();
         $object = new Object_Mock($composite, '');
     }
 
     public function testMethodConstructHasParameterStringTheGuidOfTheObject()
     {
+        $this->expectNotToPerformAssertions();
+
         $composite = $this->getComposite();
         $object = new Object_Mock($composite, 'guid');
     }
@@ -207,7 +211,7 @@ class Horde_Kolab_Server_Class_Server_Object_BaseTest extends Horde_Kolab_Server
             ->method('getExternalAttributes')
             ->with($this->isInstanceOf('Horde_Kolab_Server_Object_Interface'))
             ->will($this->returnValue(array('objectClass')));
-        $external = $this->getMock('Horde_Kolab_Server_Object_Attribute_Interface');
+        $external = $this->getMockBuilder('Horde_Kolab_Server_Object_Attribute_Interface')->getMock();
         $external->expects($this->once())
             ->method('value')
             ->will($this->returnValue(array('test')));
@@ -288,7 +292,7 @@ class Horde_Kolab_Server_Class_Server_Object_BaseTest extends Horde_Kolab_Server
                     )
                 )
             );
-        $external = $this->getMock('Horde_Kolab_Server_Object_Attribute_Interface');
+        $external = $this->getMockBuilder('Horde_Kolab_Server_Object_Attribute_Interface')->getMock();
         $external->expects($this->exactly(1))
             ->method('update')
             ->will($this->returnValue(array('objectClass' => array('top'))));

--- a/test/Horde/Kolab/Server/Class/Server/Query/Element/MappedTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Query/Element/MappedTest.php
@@ -24,20 +24,21 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Server_Class_Server_Query_Element_MappedTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->element = $this->getMock(
-            'Horde_Kolab_Server_Query_Element_Interface'
-        );
-        $this->mapper  = $this->getMock(
-            'Horde_Kolab_Server_Decorator_Map', array(), array(), '', false, false
-        );
+        $this->element = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
+        $this->mapper  = $this->getMockBuilder('Horde_Kolab_Server_Decorator_Map')
+                              ->disableOriginalConstructor()
+                              ->disableOriginalClone()
+                              ->getMock();
     }
 
     public function testMethodConstructHasParameterElementTheDecoratedElement()
     {
+        $this->expectNotToPerformAssertions();
+
         $element = new Horde_Kolab_Server_Query_Element_Mapped(
             $this->element,
             $this->mapper
@@ -46,6 +47,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testMethodConstructHasParameterMapper()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->testMethodConstructHasParameterElementTheDecoratedElement();
     }
 
@@ -80,12 +83,8 @@ extends PHPUnit_Framework_TestCase
     public function testMethodGetelementsHasResultArrayOfMappedElements()
     {
         $elements = array(
-            $this->getMock(
-                'Horde_Kolab_Server_Query_Element_Interface'
-            ),
-            $this->getMock(
-                'Horde_Kolab_Server_Query_Element_Interface'
-            ),
+            $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock(),
         );
         $this->element->expects($this->once())
             ->method('getElements')
@@ -111,7 +110,7 @@ extends PHPUnit_Framework_TestCase
             $this->element,
             $this->mapper
         );
-        $query = $this->getMock('Horde_Kolab_Server_Query_Interface');
+        $query = $this->getMockBuilder('Horde_Kolab_Server_Query_Interface')->getMock();
         $this->assertEquals('test', $element->convert($query));
     }
 
@@ -158,7 +157,7 @@ extends PHPUnit_Framework_TestCase
             $this->element,
             $this->mapper
         );
-        $query = $this->getMock('Horde_Kolab_Server_Query_Interface');
+        $query = $this->getMockBuilder('Horde_Kolab_Server_Query_Interface')->getMock();
         $element->convert($query);
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Query/Element/MappedTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Query/Element/MappedTest.php
@@ -23,6 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Query_Element_MappedTest
 extends Horde_Test_Case
 {

--- a/test/Horde/Kolab/Server/Class/Server/Query/ElementTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Query/ElementTest.php
@@ -23,13 +23,13 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Class_Server_Query_ElementTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_Class_Server_Query_ElementTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->writer = $this->getMock(
-            'Horde_Kolab_Server_Query_Ldap', array(), array(), '', false
-        );
+        $this->writer = $this->getMockBuilder('Horde_Kolab_Server_Query_Ldap')
+                             ->disableOriginalConstructor()
+                             ->getMock();
     }
 
     public function testClassAndMethodConvertHasResultMixedTheConvertedElement()
@@ -108,7 +108,7 @@ class Horde_Kolab_Server_Class_Server_Query_ElementTest extends PHPUnit_Framewor
     {
         $less = new Horde_Kolab_Server_Query_Element_Less('', '');
         $not = new Horde_Kolab_Server_Query_Element_Not($less);
-        $this->assertInternalType('array', $not->getElements());
+        $this->assertIsArray($not->getElements());
     }
 
     public function testClassNotMethodConvertHasResultMixedTheConvertedElement()
@@ -132,6 +132,8 @@ class Horde_Kolab_Server_Class_Server_Query_ElementTest extends PHPUnit_Framewor
 
     public function testClassGroupMethodConstructHasParameterArrayElements()
     {
+        $this->expectNotToPerformAssertions();
+
         $or = new Horde_Kolab_Server_Query_Element_Or(array());
     }
 
@@ -141,20 +143,18 @@ class Horde_Kolab_Server_Class_Server_Query_ElementTest extends PHPUnit_Framewor
         $this->assertEquals(array(), $or->getElements());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Server_Exception
-     */
     public function testClassGroupMethodGetnameThrowsException()
     {
+        $this->expectException('Horde_Kolab_Server_Exception');
+
         $or = new Horde_Kolab_Server_Query_Element_Or(array());
         $or->getName();
     }
 
-    /**
-     * @expectedException Horde_Kolab_Server_Exception
-     */
     public function testClassGroupMethodGetvalueThrowsException()
     {
+        $this->expectException('Horde_Kolab_Server_Exception');
+
         $or = new Horde_Kolab_Server_Query_Element_Or(array());
         $or->getValue();
     }
@@ -167,11 +167,15 @@ class Horde_Kolab_Server_Class_Server_Query_ElementTest extends PHPUnit_Framewor
 
     public function testClassSingleMethodConstructHasParameterStringName()
     {
+        $this->expectNotToPerformAssertions();
+
         $equals = new Horde_Kolab_Server_Query_Element_Equals('name', '');
     }
 
     public function testClassSingleMethodConstructHasParameterStringValue()
     {
+        $this->expectNotToPerformAssertions();
+
         $equals = new Horde_Kolab_Server_Query_Element_Equals('', 'value');
     }
 
@@ -194,11 +198,10 @@ class Horde_Kolab_Server_Class_Server_Query_ElementTest extends PHPUnit_Framewor
         $this->assertEquals('value', $equals->getValue());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Server_Exception
-     */
     public function testClassSingleMethodGetelementsThrowsException()
     {
+        $this->expectException('Horde_Kolab_Server_Exception');
+
         $equals = new Horde_Kolab_Server_Query_Element_Equals('', '');
         $equals->getElements();
     }

--- a/test/Horde/Kolab/Server/Class/Server/Query/ElementTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Query/ElementTest.php
@@ -23,6 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Query_ElementTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Query/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Query/LdapTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Query_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Query/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Query/LdapTest.php
@@ -30,16 +30,16 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  */
 class Horde_Kolab_Server_Class_Server_Query_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->skipIfNoLdap();
-        $this->structure = $this->getMock(
-            'Horde_Kolab_Server_Structure_Interface'
-        );
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodConstructHasParameterQueryelementTheQueryCriteria()
     {
+        $this->expectNotToPerformAssertions();
+
         $equals = new Horde_Kolab_Server_Query_Element_Equals('equals', 'equals');
         $query = new Horde_Kolab_Server_Query_Ldap($equals, $this->structure);
     }

--- a/test/Horde/Kolab/Server/Class/Server/Result/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Result/LdapTest.php
@@ -30,25 +30,28 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  */
 class Horde_Kolab_Server_Class_Server_Result_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->skipIfNoLdap();
     }
 
     public function testMethodConstructHasParameterNetldap2searchSearchResult()
     {
-        $search = $this->getMock(
-            'Horde_Ldap_Search', array(), array(), '', false
-        );
+        $this->expectNotToPerformAssertions();
+
+        $search = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $result = new Horde_Kolab_Server_Result_Ldap($search);
     }
 
 
     public function testMethodCountHasResultIntTheNumberOfElementsFound()
     {
-        $search = $this->getMock(
-            'Horde_Ldap_Search', array('count'), array(), '', false
-        );
+        $search = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('count'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $search->expects($this->exactly(1))
             ->method('count')
             ->will($this->returnValue(1));
@@ -58,9 +61,10 @@ class Horde_Kolab_Server_Class_Server_Result_LdapTest extends Horde_Kolab_Server
 
     public function testMethodSizelimitexceededHasResultBooleanIndicatingIfTheSearchSizeLimitWasHit()
     {
-        $search = $this->getMock(
-            'Horde_Ldap_Search', array('sizeLimitExceeded'), array(), '', false
-        );
+        $search = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('sizeLimitExceeded'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $search->expects($this->exactly(1))
             ->method('sizeLimitExceeded')
             ->will($this->returnValue(true));
@@ -70,9 +74,10 @@ class Horde_Kolab_Server_Class_Server_Result_LdapTest extends Horde_Kolab_Server
 
     public function testMethodAsarrayHasResultArrayWithTheSearchResults()
     {
-        $search = $this->getMock(
-            'Horde_Ldap_Search', array('asArray'), array(), '', false
-        );
+        $search = $this->getMockBuilder('Horde_Ldap_Search')
+                       ->setMethods(array('asArray'))
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $search->expects($this->exactly(1))
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));

--- a/test/Horde/Kolab/Server/Class/Server/Search/BaseTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/BaseTest.php
@@ -68,7 +68,7 @@ extends Horde_Kolab_Server_TestCase
         try {
             $search->setComposite($composite);
         } catch (Horde_Kolab_Server_Exception $e) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'getSearchOperations specified non-existing class "Object_Search_NoSuchClass"!',
                 $e->getMessage()
             );
@@ -115,14 +115,14 @@ extends Horde_Kolab_Server_TestCase
             $search->search();
             $this->fail('No exception!');
         } catch (Horde_Kolab_Server_Exception $e) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'does not support method "search"',
                 $e->getMessage()
             );
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Object_Search::reset();
     }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidTest.php
@@ -23,6 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidTest
 extends Horde_Test_Case
 {

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidTest.php
@@ -24,15 +24,17 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodConstructHasParameterStructure()
     {
+        $this->expectNotToPerformAssertions();
+
         $search = new Horde_Kolab_Server_Search_Operation_Guid($this->structure);
     }
 
@@ -50,7 +52,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testMethodSearchguidHasResultArrayTheGuidsOfTheSearchResult()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -64,13 +66,13 @@ extends PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Guid($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchGuid($criteria));
     }
 
     public function testMethodSearchguidHasResultArrayEmptyIfTheSearchReturnedNoResults()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array()));
@@ -84,7 +86,7 @@ extends PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Guid($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array(), $search->searchGuid($criteria));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforaliasTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforaliasTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidforaliasTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforaliasTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforaliasTest.php
@@ -31,14 +31,14 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidforaliasTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodRestrictkolabHasResultRestrictedToKolabUsers()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -53,7 +53,7 @@ extends Horde_Kolab_Server_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Guidforalias($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchGuidForAlias('test'));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforcnTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforcnTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidforcnTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforcnTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforcnTest.php
@@ -31,14 +31,14 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidforcnTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodRestrictkolabHasResultRestrictedToKolabUsers()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -50,7 +50,7 @@ extends Horde_Kolab_Server_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Guidforcn($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchGuidForCn('test'));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidformailTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidformailTest.php
@@ -31,14 +31,14 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidformailTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodRestrictkolabHasResultRestrictedToKolabUsers()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -53,7 +53,7 @@ extends Horde_Kolab_Server_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Guidformail($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchGuidForMail('test'));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidformailTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidformailTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidformailTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforuidTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforuidTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidforuidTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforuidTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/GuidforuidTest.php
@@ -31,14 +31,14 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Search_Operation_GuidforuidTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodRestrictkolabHasResultRestrictedToKolabUsers()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -53,7 +53,7 @@ extends Horde_Kolab_Server_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Guidforuid($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchGuidForUid('test'));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictgroupsTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictgroupsTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_RestrictgroupsTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictgroupsTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictgroupsTest.php
@@ -31,14 +31,14 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Search_Operation_RestrictgroupsTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodSearchrestrictgroupsHasResultRestrictedToGroups()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -50,7 +50,7 @@ extends Horde_Kolab_Server_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Restrictgroups($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchRestrictGroups($criteria));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictkolabTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictkolabTest.php
@@ -31,14 +31,14 @@ require_once __DIR__ . '/../../../../TestCase.php';
 class Horde_Kolab_Server_Class_Server_Search_Operation_RestrictkolabTest
 extends Horde_Kolab_Server_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->structure = $this->getMock('Horde_Kolab_Server_Structure_Interface');
+        $this->structure = $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')->getMock();
     }
 
     public function testMethodRestrictkolabHasResultRestrictedToKolabUsers()
     {
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $result->expects($this->once())
             ->method('asArray')
             ->will($this->returnValue(array('a' => 'a')));
@@ -50,7 +50,7 @@ extends Horde_Kolab_Server_TestCase
             )
             ->will($this->returnValue($result));
         $search = new Horde_Kolab_Server_Search_Operation_Restrictkolab($this->structure);
-        $criteria = $this->getMock('Horde_Kolab_Server_Query_Element_Interface');
+        $criteria = $this->getMockBuilder('Horde_Kolab_Server_Query_Element_Interface')->getMock();
         $this->assertEquals(array('a'), $search->searchRestrictkolab($criteria));
     }
 }

--- a/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictkolabTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Search/Operation/RestrictkolabTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../../TestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Search_Operation_RestrictkolabTest
 extends Horde_Kolab_Server_TestCase
 {

--- a/test/Horde/Kolab/Server/Class/Server/Structure/KolabTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Structure/KolabTest.php
@@ -23,6 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Structure_KolabTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Class/Server/Structure/KolabTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Structure/KolabTest.php
@@ -23,23 +23,23 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Class_Server_Structure_KolabTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_Class_Server_Structure_KolabTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $server = $this->getMock('Horde_Kolab_Server_Interface');
+        $server = $this->getMockBuilder('Horde_Kolab_Server_Interface')->getMock();
         $this->composite = new Horde_Kolab_Server_Composite(
             $server,
-            $this->getMock('Horde_Kolab_Server_Objects_Interface'),
+            $this->getMockBuilder('Horde_Kolab_Server_Objects_Interface')->getMock(),
             new Horde_Kolab_Server_Structure_Kolab(),
-            $this->getMock('Horde_Kolab_Server_Search_Interface'),
-            $this->getMock('Horde_Kolab_Server_Schema_Interface')
+            $this->getMockBuilder('Horde_Kolab_Server_Search_Interface')->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Schema_Interface')->getMock()
         );
     }
 
     public function testMethodGetsupportedobjectsHasResultArrayTheObjectTypesSupportedByThisStructure()
     {
-        $this->assertInternalType('array', $this->composite->structure->getSupportedObjects());
+        $this->assertIsArray($this->composite->structure->getSupportedObjects());
     }
 
     public function testMethodDeterminetypeHasResultStringTheObjectclassOfTheGivenGuid1()

--- a/test/Horde/Kolab/Server/Class/Server/Structure/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Structure/LdapTest.php
@@ -30,22 +30,22 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  */
 class Horde_Kolab_Server_Class_Server_Structure_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $server = $this->getMock('Horde_Kolab_Server_Interface');
+        $server = $this->getMockBuilder('Horde_Kolab_Server_Interface')->getMock();
         $this->composite = new Horde_Kolab_Server_Composite(
             $server,
-            $this->getMock('Horde_Kolab_Server_Objects_Interface'),
+            $this->getMockBuilder('Horde_Kolab_Server_Objects_Interface')->getMock(),
             new Horde_Kolab_Server_Structure_Ldap(),
-            $this->getMock('Horde_Kolab_Server_Search_Interface'),
-            $this->getMock('Horde_Kolab_Server_Schema_Interface')
+            $this->getMockBuilder('Horde_Kolab_Server_Search_Interface')->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Schema_Interface')->getMock()
         );
     }
 
     public function testMethodFindHasResultServerResultTheSearchResult()
     {
         $this->skipIfNoLdap();
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $this->composite->server->expects($this->exactly(1))
             ->method('find')
             ->with('(objectClass=equals)', array())
@@ -60,7 +60,7 @@ class Horde_Kolab_Server_Class_Server_Structure_LdapTest extends Horde_Kolab_Ser
     public function testMethodFindBelowHasResultServerResultTheSearchResult()
     {
         $this->skipIfNoLdap();
-        $result = $this->getMock('Horde_Kolab_Server_Result_Interface');
+        $result = $this->getMockBuilder('Horde_Kolab_Server_Result_Interface')->getMock();
         $this->composite->server->expects($this->exactly(1))
             ->method('findBelow')
             ->with('(objectClass=equals)', 'base', array())

--- a/test/Horde/Kolab/Server/Class/Server/Structure/LdapTest.php
+++ b/test/Horde/Kolab/Server/Class/Server/Structure/LdapTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../../../LdapTestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Class_Server_Structure_LdapTest extends Horde_Kolab_Server_LdapTestCase
 {
     public function setUp(): void

--- a/test/Horde/Kolab/Server/Constraints/Restrictgroups.php
+++ b/test/Horde/Kolab/Server/Constraints/Restrictgroups.php
@@ -1,6 +1,6 @@
 <?php
 
-class Horde_Kolab_Server_Constraint_Restrictgroups extends PHPUnit_Framework_Constraint
+class Horde_Kolab_Server_Constraint_Restrictgroups extends PHPUnit\Framework\Constraint\Constraint
 {
     public function evaluate($other, $description = '', $returnResult = FALSE)
     {
@@ -26,7 +26,7 @@ class Horde_Kolab_Server_Constraint_Restrictgroups extends PHPUnit_Framework_Con
         }
     }
 
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL): void
     {
         throw new PHPUnit_Framework_ExpectationFailedException(
           sprintf(
@@ -39,7 +39,7 @@ class Horde_Kolab_Server_Constraint_Restrictgroups extends PHPUnit_Framework_Con
         );
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'contains a query element that restricts the search to groups';
     }

--- a/test/Horde/Kolab/Server/Constraints/Restrictgroups.php
+++ b/test/Horde/Kolab/Server/Constraints/Restrictgroups.php
@@ -2,7 +2,7 @@
 
 class Horde_Kolab_Server_Constraint_Restrictgroups extends PHPUnit\Framework\Constraint\Constraint
 {
-    public function evaluate($other, $description = '', $returnResult = FALSE)
+    public function evaluate($other, $description = '', $returnResult = FALSE): ?bool
     {
         if ($other instanceof Horde_Kolab_Server_Query_Element_Interface) {
             if ($other instanceof Horde_Kolab_Server_Query_Element_Group) {

--- a/test/Horde/Kolab/Server/Constraints/Restrictkolabusers.php
+++ b/test/Horde/Kolab/Server/Constraints/Restrictkolabusers.php
@@ -2,7 +2,7 @@
 
 class Horde_Kolab_Server_Constraint_Restrictedkolabusers extends PHPUnit\Framework\Constraint\Constraint
 {
-    public function evaluate($other, $description = '', $returnResult = FALSE)
+    public function evaluate($other, $description = '', $returnResult = FALSE): ?bool
     {
         if ($other instanceof Horde_Kolab_Server_Query_Element_Interface) {
             if ($other instanceof Horde_Kolab_Server_Query_Element_Group) {

--- a/test/Horde/Kolab/Server/Constraints/Restrictkolabusers.php
+++ b/test/Horde/Kolab/Server/Constraints/Restrictkolabusers.php
@@ -1,6 +1,6 @@
 <?php
 
-class Horde_Kolab_Server_Constraint_Restrictedkolabusers extends PHPUnit_Framework_Constraint
+class Horde_Kolab_Server_Constraint_Restrictedkolabusers extends PHPUnit\Framework\Constraint\Constraint
 {
     public function evaluate($other, $description = '', $returnResult = FALSE)
     {
@@ -26,7 +26,7 @@ class Horde_Kolab_Server_Constraint_Restrictedkolabusers extends PHPUnit_Framewo
         }
     }
 
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL): void
     {
         throw new PHPUnit_Framework_ExpectationFailedException(
           sprintf(
@@ -39,7 +39,7 @@ class Horde_Kolab_Server_Constraint_Restrictedkolabusers extends PHPUnit_Framewo
         );
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'contains a query element that restricts the search to Kolab users';
     }

--- a/test/Horde/Kolab/Server/Constraints/Searchalias.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchalias.php
@@ -1,6 +1,6 @@
 <?php
 
-class Horde_Kolab_Server_Constraint_Searchalias extends PHPUnit_Framework_Constraint
+class Horde_Kolab_Server_Constraint_Searchalias extends PHPUnit\Framework\Constraint\Constraint
 {
     public function evaluate($other, $description = '', $returnResult = FALSE)
     {
@@ -25,7 +25,7 @@ class Horde_Kolab_Server_Constraint_Searchalias extends PHPUnit_Framework_Constr
         }
     }
 
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL): void
     {
         throw new PHPUnit_Framework_ExpectationFailedException(
           sprintf(
@@ -38,7 +38,7 @@ class Horde_Kolab_Server_Constraint_Searchalias extends PHPUnit_Framework_Constr
         );
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'contains a query element that is searching by alias';
     }

--- a/test/Horde/Kolab/Server/Constraints/Searchalias.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchalias.php
@@ -2,7 +2,7 @@
 
 class Horde_Kolab_Server_Constraint_Searchalias extends PHPUnit\Framework\Constraint\Constraint
 {
-    public function evaluate($other, $description = '', $returnResult = FALSE)
+    public function evaluate($other, $description = '', $returnResult = FALSE): ?bool
     {
         if ($other instanceof Horde_Kolab_Server_Query_Element_Interface) {
             if ($other instanceof Horde_Kolab_Server_Query_Element_Group) {

--- a/test/Horde/Kolab/Server/Constraints/Searchcn.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchcn.php
@@ -1,6 +1,6 @@
 <?php
 
-class Horde_Kolab_Server_Constraint_Searchcn extends PHPUnit_Framework_Constraint
+class Horde_Kolab_Server_Constraint_Searchcn extends PHPUnit\Framework\Constraint\Constraint
 {
     public function evaluate($other, $description = '', $returnResult = FALSE)
     {
@@ -25,7 +25,7 @@ class Horde_Kolab_Server_Constraint_Searchcn extends PHPUnit_Framework_Constrain
         }
     }
 
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL): void
     {
         throw new PHPUnit_Framework_ExpectationFailedException(
           sprintf(
@@ -38,7 +38,7 @@ class Horde_Kolab_Server_Constraint_Searchcn extends PHPUnit_Framework_Constrain
         );
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'contains a query element that is searching by cn';
     }

--- a/test/Horde/Kolab/Server/Constraints/Searchcn.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchcn.php
@@ -2,7 +2,7 @@
 
 class Horde_Kolab_Server_Constraint_Searchcn extends PHPUnit\Framework\Constraint\Constraint
 {
-    public function evaluate($other, $description = '', $returnResult = FALSE)
+    public function evaluate($other, $description = '', $returnResult = FALSE): ?bool
     {
         if ($other instanceof Horde_Kolab_Server_Query_Element_Interface) {
             if ($other instanceof Horde_Kolab_Server_Query_Element_Group) {

--- a/test/Horde/Kolab/Server/Constraints/Searchmail.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchmail.php
@@ -1,6 +1,6 @@
 <?php
 
-class Horde_Kolab_Server_Constraint_Searchmail extends PHPUnit_Framework_Constraint
+class Horde_Kolab_Server_Constraint_Searchmail extends PHPUnit\Framework\Constraint\Constraint
 {
     public function evaluate($other, $description = '', $returnResult = FALSE)
     {
@@ -25,7 +25,7 @@ class Horde_Kolab_Server_Constraint_Searchmail extends PHPUnit_Framework_Constra
         }
     }
 
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL): void
     {
         throw new PHPUnit_Framework_ExpectationFailedException(
           sprintf(
@@ -38,7 +38,7 @@ class Horde_Kolab_Server_Constraint_Searchmail extends PHPUnit_Framework_Constra
         );
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'contains a query element that is searching by mail';
     }

--- a/test/Horde/Kolab/Server/Constraints/Searchmail.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchmail.php
@@ -2,7 +2,7 @@
 
 class Horde_Kolab_Server_Constraint_Searchmail extends PHPUnit\Framework\Constraint\Constraint
 {
-    public function evaluate($other, $description = '', $returnResult = FALSE)
+    public function evaluate($other, $description = '', $returnResult = FALSE): ?bool
     {
         if ($other instanceof Horde_Kolab_Server_Query_Element_Interface) {
             if ($other instanceof Horde_Kolab_Server_Query_Element_Group) {

--- a/test/Horde/Kolab/Server/Constraints/Searchuid.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchuid.php
@@ -1,6 +1,6 @@
 <?php
 
-class Horde_Kolab_Server_Constraint_Searchuid extends PHPUnit_Framework_Constraint
+class Horde_Kolab_Server_Constraint_Searchuid extends PHPUnit\Framework\Constraint\Constraint
 {
     public function evaluate($other, $description = '', $returnResult = FALSE)
     {
@@ -25,7 +25,7 @@ class Horde_Kolab_Server_Constraint_Searchuid extends PHPUnit_Framework_Constrai
         }
     }
 
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure = NULL): void
     {
         throw new PHPUnit_Framework_ExpectationFailedException(
           sprintf(
@@ -38,7 +38,7 @@ class Horde_Kolab_Server_Constraint_Searchuid extends PHPUnit_Framework_Constrai
         );
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'contains a query element that is searching by uid';
     }

--- a/test/Horde/Kolab/Server/Constraints/Searchuid.php
+++ b/test/Horde/Kolab/Server/Constraints/Searchuid.php
@@ -2,7 +2,7 @@
 
 class Horde_Kolab_Server_Constraint_Searchuid extends PHPUnit\Framework\Constraint\Constraint
 {
-    public function evaluate($other, $description = '', $returnResult = FALSE)
+    public function evaluate($other, $description = '', $returnResult = FALSE): ?bool
     {
         if ($other instanceof Horde_Kolab_Server_Query_Element_Interface) {
             if ($other instanceof Horde_Kolab_Server_Query_Element_Group) {

--- a/test/Horde/Kolab/Server/Integration/AddingObjectsTest.php
+++ b/test/Horde/Kolab/Server/Integration/AddingObjectsTest.php
@@ -30,6 +30,12 @@ require_once __DIR__ . '/Scenario.php';
  */
 class Horde_Kolab_Server_Integration_AddingObjectsTest extends Horde_Kolab_Server_Integration_Scenario
 {
+
+    public function testNothing()
+    {
+        $this->expectNotToPerformAssertions();
+    }
+
     /**
      * Test adding valid users.
      *

--- a/test/Horde/Kolab/Server/Integration/AdminTest.php
+++ b/test/Horde/Kolab/Server/Integration/AdminTest.php
@@ -36,7 +36,7 @@ class Horde_Kolab_Server_Integration_AdminTest extends Horde_Kolab_Server_Integr
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/DistListHandlingTest.php
+++ b/test/Horde/Kolab/Server/Integration/DistListHandlingTest.php
@@ -30,6 +30,10 @@ require_once __DIR__ . '/Scenario.php';
  */
 class Horde_Kolab_Server_Integration_DistListHandlingTest extends Horde_Kolab_Server_Integration_Scenario
 {
+    public function testNothing()
+    {
+        $this->expectNotToPerformAssertions();
+    }
 
     /**
      * Test adding a distribution list.

--- a/test/Horde/Kolab/Server/Integration/GroupTest.php
+++ b/test/Horde/Kolab/Server/Integration/GroupTest.php
@@ -36,7 +36,7 @@ class Horde_Kolab_Server_Integration_GroupTest extends Horde_Kolab_Server_Integr
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/InetorgpersonTest.php
+++ b/test/Horde/Kolab/Server/Integration/InetorgpersonTest.php
@@ -64,7 +64,7 @@ class Horde_Kolab_Server_Integration_InetorgpersonTest extends Horde_Kolab_Serve
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/KolabgermanbankarrangementTest.php
+++ b/test/Horde/Kolab/Server/Integration/KolabgermanbankarrangementTest.php
@@ -56,7 +56,7 @@ class Horde_Kolab_Server_Integration_KolabgermanbankarrangementTest extends Hord
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/KolabinetorgpersonTest.php
+++ b/test/Horde/Kolab/Server/Integration/KolabinetorgpersonTest.php
@@ -56,7 +56,7 @@ class Horde_Kolab_Server_Integration_KolabinetorgpersonTest extends Horde_Kolab_
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/Kolabpop3accountTest.php
+++ b/test/Horde/Kolab/Server/Integration/Kolabpop3accountTest.php
@@ -58,7 +58,7 @@ class Horde_Kolab_Server_Integration_Kolabpop3accountTest extends Horde_Kolab_Se
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/MockTest.php
+++ b/test/Horde/Kolab/Server/Integration/MockTest.php
@@ -75,7 +75,7 @@ class Horde_Kolab_Server_Integration_MockTest extends Horde_Kolab_Server_Integra
      *
      * @return NULL
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/ObjectTest.php
+++ b/test/Horde/Kolab/Server/Integration/ObjectTest.php
@@ -38,7 +38,7 @@ class Horde_Kolab_Server_Integration_ObjectTest extends Horde_Kolab_Server_Integ
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/ObjectsTest.php
+++ b/test/Horde/Kolab/Server/Integration/ObjectsTest.php
@@ -23,9 +23,9 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Integration_ObjectsTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_Integration_ObjectsTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Needs to be fixed');
     }

--- a/test/Horde/Kolab/Server/Integration/OrgPersonTest.php
+++ b/test/Horde/Kolab/Server/Integration/OrgPersonTest.php
@@ -56,7 +56,7 @@ class Horde_Kolab_Server_Integration_OrgPersonTest extends Horde_Kolab_Server_In
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/PersonTest.php
+++ b/test/Horde/Kolab/Server/Integration/PersonTest.php
@@ -110,7 +110,7 @@ class Horde_Kolab_Server_Integration_PersonTest extends Horde_Kolab_Server_Integ
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/Integration/Scenario.php
+++ b/test/Horde/Kolab/Server/Integration/Scenario.php
@@ -23,7 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_Integration_Scenario extends PHPUnit_Extensions_Story_TestCase
+class Horde_Kolab_Server_Integration_Scenario extends Horde_Test_Case
 {
     /** The mock environment */
     const ENVIRONMENT_MOCK = 'mock';
@@ -1052,7 +1052,7 @@ class Horde_Kolab_Server_Integration_Scenario extends PHPUnit_Extensions_Story_T
      *
      * @return NULL.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->added = array();
         $this->markTestIncomplete('Needs to be fixed');
@@ -1063,7 +1063,7 @@ class Horde_Kolab_Server_Integration_Scenario extends PHPUnit_Extensions_Story_T
      *
      * @return NULL.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (isset($this->added)) {
             $added = array_reverse($this->added);

--- a/test/Horde/Kolab/Server/Integration/SearchTest.php
+++ b/test/Horde/Kolab/Server/Integration/SearchTest.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/../LdapTestCase.php';
 class Horde_Kolab_Server_Integration_SearchTest
 extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
 
 /*         $injector = new Horde_Injector(new Horde_Injector_TopLevel()); */
@@ -41,6 +41,7 @@ extends Horde_Kolab_Server_LdapTestCase
 
     public function testNothing()
     {
+        $this->expectNotToPerformAssertions();
     }
 
     /**

--- a/test/Horde/Kolab/Server/Integration/SearchguidforuidormailTest.php
+++ b/test/Horde/Kolab/Server/Integration/SearchguidforuidormailTest.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/../LdapTestCase.php';
 class Horde_Kolab_Server_Integration_SearchguidforuidormailTest
 extends Horde_Kolab_Server_LdapTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->skipIfNoLdap();
         $connection = new Horde_Kolab_Server_Connection_Mock(
@@ -65,6 +65,8 @@ extends Horde_Kolab_Server_LdapTestCase
 
     public function testSearchingForUnknownUserReturnsEmptyGuid()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->composite->search->searchGuidForUidOrMail('unknown');
     }
 

--- a/test/Horde/Kolab/Server/Integration/SearchguidforuidormailTest.php
+++ b/test/Horde/Kolab/Server/Integration/SearchguidforuidormailTest.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/../LdapTestCase.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Kolab_Server_Integration_SearchguidforuidormailTest
 extends Horde_Kolab_Server_LdapTestCase
 {

--- a/test/Horde/Kolab/Server/Integration/UserTest.php
+++ b/test/Horde/Kolab/Server/Integration/UserTest.php
@@ -36,7 +36,7 @@ class Horde_Kolab_Server_Integration_UserTest extends Horde_Kolab_Server_Integra
      *
      * @return NULL
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/Horde/Kolab/Server/TestCase.php
+++ b/test/Horde/Kolab/Server/TestCase.php
@@ -33,23 +33,29 @@ require_once __DIR__ . '/Constraints/Searchalias.php';
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Server_TestCase extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Server_TestCase extends Horde_Test_Case
 {
     protected function getComposite()
     {
-        return $this->getMock(
-            'Horde_Kolab_Server_Composite', array(), array(), '', false, false
-        );
+        return $this->getMockBuilder('Horde_Kolab_Server_Composite')
+                    ->disableOriginalConstructor()
+                    ->disableOriginalClone()
+                    ->getMock();
     }
 
     protected function getMockedComposite()
     {
         return new Horde_Kolab_Server_Composite(
-            $this->getMock('Horde_Kolab_Server_Interface'),
-            $this->getMock('Horde_Kolab_Server_Objects_Interface'),
-            $this->getMock('Horde_Kolab_Server_Structure_Interface'),
-            $this->getMock('Horde_Kolab_Server_Search_Interface'),
-            $this->getMock('Horde_Kolab_Server_Schema_Interface')
+            $this->getMockBuilder('Horde_Kolab_Server_Interface')
+                 ->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Objects_Interface')
+                 ->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Structure_Interface')
+                 ->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Search_Interface')
+                 ->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Server_Schema_Interface')
+                 ->getMock()
         );
     }
 


### PR DESCRIPTION
- Debian changes:  Fix tests with PHPUnit 8.x/9.x. https://salsa.debian.org/horde-team/php-horde-kolab-server/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Calling interface methods is not support anymore since PHP 7.4 https://salsa.debian.org/horde-team/php-horde-kolab-server/-/blob/debian-sid/debian/patches/1011_dont-call-parents-that-are-interface-methods.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-kolab-server/-/blob/debian-sid/debian/patches/1012_php8.2.patch
- Debian changes: Add 1020_fix-phpunit-crash.patch. Avoid crash of phpunit. https://salsa.debian.org/horde-team/php-horde-kolab-server/-/blob/debian-sid/debian/patches/1020_fix-phpunit-crash.patch
